### PR TITLE
add testpilot as a plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "carlaviz"]
 	path = carlaviz
 	url = https://github.com/carla-simulator/carlaviz.git
+[submodule "testpilot"]
+	path = testpilot
+	url = https://github.com/Trustworthy-AI/testpilot.git

--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@ Current contributions:
 
 * [CV] **CarlaViz**: Visualize carla in the web browser (Minjun Xu: mjxu96@gmail.com)
 
+* [TP] **TestPilot**: Run a minimally invasive fork of Comma AI's OpenPilot 0.5 designed for synchronous simulation (Trustworthy AI: trustworthy.ai)
+


### PR DESCRIPTION
This plugin creates a docker container to run a fork of Comma.ai's OpenPilot 0.5. The perception, planning, and control systems run synchronously in this fork. An example of running the system is provided in the demo/demo.py script. More information about the fork is at https://arxiv.org/abs/1912.03618.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla-plugins/2)
<!-- Reviewable:end -->
